### PR TITLE
Constant updated: MATHJAX_JS_VERSION

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,22 @@
 {
     "name": "terrylinooo/wp-mathjax",
     "description": "Render your MathJax TeX syntax on WordPress.",
-    "keywords": ["wordpress-plugin", "math", "mathjax"],
+    "keywords": [
+        "wordpress-plugin",
+        "math",
+        "mathjax"
+    ],
     "homepage": "https://github.com/terrylinooo/wp-mathjax",
     "license": "GPL-3.0-or-later",
-    "authors": [
-        {
+    "authors": [{
             "name": "Terry Lin",
             "email": "contact@terryl.in",
             "homepage": "https://terryl.in/zh/"
+        },
+        {
+            "name": "AH-dark",
+            "email": "ahdark@roundcloud.cn",
+            "homepage": "https://ahdark.rc0.co"
         }
     ]
 }

--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Menu.
  *
@@ -8,19 +9,20 @@
  * @version 1.0.0
  */
 
-add_action( 'admin_menu', 'wp_mathjax_option' );
+add_action('admin_menu', 'wp_mathjax_option');
 
 /**
  * Register the plugin setting page.
  *
  * @return void
  */
-function wp_mathjax_option() {
-	
-	if ( function_exists( 'add_options_page' ) ) {
+function wp_mathjax_option()
+{
+
+	if (function_exists('add_options_page')) {
 		add_options_page(
-			__( 'WP MathJax', 'wp-mathjax' ),
-			__( 'WP MathJax', 'wp-mathjax' ),
+			__('WP MathJax', 'wp-mathjax'),
+			__('WP MathJax', 'wp-mathjax'),
 			'manage_options',
 			'wp-mathjax.php',
 			'wp_mathjax_options_page'
@@ -33,47 +35,48 @@ function wp_mathjax_option() {
  *
  * @return void
  */
-function wp_mathjax_options_page() {
-	?>
-   <div class="wrap">
-	   <h1>WP MathJax 
+function wp_mathjax_options_page()
+{
+?>
+	<div class="wrap">
+		<h1>WP MathJax
 			<small style="font-size: 12px;">
 				<a href="https://github.com/terrylinooo/wp-mathjax" target="_blank" style="text-decoration: none">
 					<?php echo MATHJAX_PLUGIN_VERSION; ?>
-				</a> by 
+				</a> by
 				<a href="https://github.com/terrylinooo" target="_blank" style="text-decoration: none">
 					TerryL
 				</a>
 			</small>
 		</h1>
-	   <hr />
-	   <form action="options.php" method="post">
-		   <?php settings_fields( 'wp_mathjax_setting_group' ); ?>
-		   <?php do_settings_sections( 'wp_mathjax_setting_group' );  ?>
-		   <hr />
-		   <?php submit_button(); ?>
-	   </form>
-   </div>
-   <div class="wrap">
-   		<hr />
-		<h3><?php echo __( 'How to Use', 'wp-mathjax' ); ?></h3>
+		<hr />
+		<form action="options.php" method="post">
+			<?php settings_fields('wp_mathjax_setting_group'); ?>
+			<?php do_settings_sections('wp_mathjax_setting_group');  ?>
+			<hr />
+			<?php submit_button(); ?>
+		</form>
+	</div>
+	<div class="wrap">
+		<hr />
+		<h3><?php echo __('How to Use', 'wp-mathjax'); ?></h3>
 		<blockquote>
-			<h4><?php echo __( 'Shortcode', 'wp-mathjax' ); ?></h4>
+			<h4><?php echo __('Shortcode', 'wp-mathjax'); ?></h4>
 			<blockquote>
 				<p>
-					<?php echo __( 'In classic editor, you can use shortcode to render your MathJax syntax.', 'wp-mathjax' ); ?><br />
-					<?php echo __( 'If you are using WordPress version below 5.0, this is the only way you can use.', 'wp-mathjax' ); ?>
+					<?php echo __('In classic editor, you can use shortcode to render your MathJax syntax.', 'wp-mathjax'); ?><br />
+					<?php echo __('If you are using WordPress version below 5.0, this is the only way you can use.', 'wp-mathjax'); ?>
 				</p>
 				<code style="background-color: white; padding: 10px; margin: 10px 0; display: inline-block;">[mathjax] ... [/mathjax]</code>
 			</blockquote>
-			<h4><?php echo __( 'Gutenberg Block', 'wp-mathjax' ); ?></h4>
+			<h4><?php echo __('Gutenberg Block', 'wp-mathjax'); ?></h4>
 			<blockquote>
-				<p><?php echo __( 'Choose MathJax block:', 'wp-mathjax' ); ?></p>
+				<p><?php echo __('Choose MathJax block:', 'wp-mathjax'); ?></p>
 				<img src="<?php echo MATHJAX_PLUGIN_URL ?>/assets/example-gutenberg-block-1.png" style="width: 500px; max-width: 95%">
-				<p><?php echo __( 'Fill in your MathJax syntax in the editor.', 'wp-mathjax' ); ?></p>
+				<p><?php echo __('Fill in your MathJax syntax in the editor.', 'wp-mathjax'); ?></p>
 				<img src="<?php echo MATHJAX_PLUGIN_URL ?>/assets/example-gutenberg-block-2.png" style="width: 500px; max-width: 95%">>
 			</blockquote>
 		</blockquote>
 	</div>
-   <?php
+<?php
 }

--- a/inc/admin/register.php
+++ b/inc/admin/register.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Activating plugin.
  *
@@ -8,17 +9,18 @@
  * @version 1.0.0
  */
 
-register_activation_hook( __FILE__, 'wp_mathjax_activation' );
-register_uninstall_hook( __FILE__, 'wp_mathjax_uninstall' );
+register_activation_hook(__FILE__, 'wp_mathjax_activation');
+register_uninstall_hook(__FILE__, 'wp_mathjax_uninstall');
 
 /**
  * Assign default setting values while activating this plugin.
  *
  * @return void
  */
-function wp_mathjax_activation() {
-	add_option( 'wp_mathjax_js_source', 'local' );
-	add_option( 'wp_mathjax_uninstall_option', 'yes' );
+function wp_mathjax_activation()
+{
+	add_option('wp_mathjax_js_source', 'local');
+	add_option('wp_mathjax_uninstall_option', 'yes');
 }
 
 /**
@@ -26,11 +28,12 @@ function wp_mathjax_activation() {
  *
  * @return void
  */
-function wp_mathjax_uninstall() {
-	$option_uninstall = get_option( 'wp_mathjax_uninstall_option' );
+function wp_mathjax_uninstall()
+{
+	$option_uninstall = get_option('wp_mathjax_uninstall_option');
 
-	if ( 'yes' === $option_uninstall ) {
-		delete_option( 'wp_mathjax_js_source' );
-		delete_option( 'wp_mathjax_uninstall_option' );
+	if ('yes' === $option_uninstall) {
+		delete_option('wp_mathjax_js_source');
+		delete_option('wp_mathjax_uninstall_option');
 	}
 }

--- a/inc/admin/setting.php
+++ b/inc/admin/setting.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Setting page.
  *
@@ -8,29 +9,30 @@
  * @version 1.0.0
  */
 
-add_action( 'admin_init', 'wp_mathjax_settings' );
+add_action('admin_init', 'wp_mathjax_settings');
 
- /**
-  * Add settings.
-  *
-  * @return void
-  */
-function wp_mathjax_settings() {
+/**
+ * Add settings.
+ *
+ * @return void
+ */
+function wp_mathjax_settings()
+{
 
-	register_setting( 'wp_mathjax_setting_group', 'wp_mathjax_js_source' );
-	register_setting( 'wp_mathjax_setting_group', 'wp_mathjax_input_type' );
-	register_setting( 'wp_mathjax_setting_group', 'wp_mathjax_uninstall_option' );
+	register_setting('wp_mathjax_setting_group', 'wp_mathjax_js_source');
+	register_setting('wp_mathjax_setting_group', 'wp_mathjax_input_type');
+	register_setting('wp_mathjax_setting_group', 'wp_mathjax_uninstall_option');
 
 	add_settings_section(
 		'wp_mathjax_basic_section_id',
-		__( 'Basic', 'wp-mathjax' ),
+		__('Basic', 'wp-mathjax'),
 		'wp_mathjax_setting_section_callback',
 		'wp_mathjax_setting_group'
 	);
 
 	add_settings_field(
 		'wp_mathjax_js_source',
-		__( 'File Host', 'wp-mathjax' ),
+		__('File Host', 'wp-mathjax'),
 		'wp_mathjax_js_source_callback',
 		'wp_mathjax_setting_group',
 		'wp_mathjax_basic_section_id'
@@ -38,7 +40,7 @@ function wp_mathjax_settings() {
 
 	add_settings_field(
 		'wp_mathjax_input_type',
-		__( 'Input Type', 'wp-mathjax' ),
+		__('Input Type', 'wp-mathjax'),
 		'wp_mathjax_input_type_callback',
 		'wp_mathjax_setting_group',
 		'wp_mathjax_basic_section_id'
@@ -46,15 +48,16 @@ function wp_mathjax_settings() {
 
 	add_settings_field(
 		'wp_mathjax_uninstall_option',
-		__( 'Uninstall Option', 'wp-mathjax' ),
+		__('Uninstall Option', 'wp-mathjax'),
 		'wp_mathjax_uninstall_option_callback',
 		'wp_mathjax_setting_group',
 		'wp_mathjax_basic_section_id'
 	);
 }
 
-function wp_mathjax_setting_section_callback() {
-	echo __( '', 'wp-mathjax' );
+function wp_mathjax_setting_section_callback()
+{
+	echo __('', 'wp-mathjax');
 }
 
 /**
@@ -62,32 +65,33 @@ function wp_mathjax_setting_section_callback() {
  *
  * @return void
  */
-function wp_mathjax_js_source_callback() {
-	$option_js_source = get_option( 'wp_mathjax_js_source', 'local' );
-	?>
+function wp_mathjax_js_source_callback()
+{
+	$option_js_source = get_option('wp_mathjax_js_source', 'local');
+?>
+	<div>
 		<div>
-			<div>
-				<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-1" value="local" <?php checked( $option_js_source, 'local' ); ?>>
-				<label for="wp-mathjax-js-library-source-1">
-				<?php echo __( 'Local', 'wp-mathjax' ); ?> (<?php echo __( 'default', 'wp-mathjax' ); ?>)
+			<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-1" value="local" <?php checked($option_js_source, 'local'); ?>>
+			<label for="wp-mathjax-js-library-source-1">
+				<?php echo __('Local', 'wp-mathjax'); ?> (<?php echo __('default', 'wp-mathjax'); ?>)
 				<label>
-			</div>
-			<div>
-				<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-1" value="cloudflare" <?php checked( $option_js_source, 'cloudflare' ); ?>>
-				<label for="wp-mathjax-js-library-source-2">
-					<?php echo __( 'cdn.cloudflare.com', 'wp-mathjax' ); ?>
-				<label>
-			
-			</div>
-			<div>
-				<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-2" <?php checked( $option_js_source, 'jsdelivr' ); ?> value="jsdelivr">
-				<label for="wp-mathjax-js-library-source-3">
-					<?php echo __( 'cdn.jsdelivr.net', 'wp-mathjax' ); ?>
-				<label>
-			</div>
 		</div>
-		<p><em><?php echo __( 'This plugin loads MathJax.js locally by default, but if you would like to use it with a CDN service, here is the option.', 'wp-mathjax' ); ?></em></p>
-	<?php
+		<div>
+			<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-1" value="cloudflare" <?php checked($option_js_source, 'cloudflare'); ?>>
+			<label for="wp-mathjax-js-library-source-2">
+				<?php echo __('cdn.cloudflare.com', 'wp-mathjax'); ?>
+				<label>
+
+		</div>
+		<div>
+			<input type="radio" name="wp_mathjax_js_source" id="wp-mathjax-js-library-source-2" <?php checked($option_js_source, 'jsdelivr'); ?> value="jsdelivr">
+			<label for="wp-mathjax-js-library-source-3">
+				<?php echo __('cdn.jsdelivr.net', 'wp-mathjax'); ?>
+				<label>
+		</div>
+	</div>
+	<p><em><?php echo __('This plugin loads MathJax.js locally by default, but if you would like to use it with a CDN service, here is the option.', 'wp-mathjax'); ?></em></p>
+<?php
 }
 
 /**
@@ -95,30 +99,31 @@ function wp_mathjax_js_source_callback() {
  *
  * @return void
  */
-function wp_mathjax_input_type_callback() {
-	$option_input_type = get_option( 'wp_mathjax_input_type', 'TeX' );
-	?>
+function wp_mathjax_input_type_callback()
+{
+	$option_input_type = get_option('wp_mathjax_input_type', 'TeX');
+?>
+	<div>
 		<div>
-			<div>
-				<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-1" value="TeX" <?php checked( $option_input_type, 'TeX' ); ?>>
-				<label for="wp-mathjax-js-library-source-1">
-				<?php echo __( 'TeX', 'wp-mathjax' ); ?> (<?php echo __( 'default', 'wp-mathjax' ); ?>)
+			<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-1" value="TeX" <?php checked($option_input_type, 'TeX'); ?>>
+			<label for="wp-mathjax-js-library-source-1">
+				<?php echo __('TeX', 'wp-mathjax'); ?> (<?php echo __('default', 'wp-mathjax'); ?>)
 				<label>
-			</div>
-			<div>
-				<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-2" value="MathML" <?php checked( $option_input_type, 'MathML' ); ?>>
-				<label for="wp-mathjax-js-library-source-2">
-					<?php echo __( 'MathML', 'wp-mathjax' ); ?>
-				<label>
-			</div>
-			<div>
-				<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-3" value="ASCIIMathML" <?php checked( $option_input_type, 'ASCIIMathML' ); ?>>
-				<label for="wp-mathjax-js-library-source-3">
-					<?php echo __( 'ASCIIMathML', 'wp-mathjax' ); ?>
-				<label>
-			</div>
 		</div>
-	<?php
+		<div>
+			<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-2" value="MathML" <?php checked($option_input_type, 'MathML'); ?>>
+			<label for="wp-mathjax-js-library-source-2">
+				<?php echo __('MathML', 'wp-mathjax'); ?>
+				<label>
+		</div>
+		<div>
+			<input type="radio" name="wp_mathjax_input_type" id="wp-mathjax-js-input-type-3" value="ASCIIMathML" <?php checked($option_input_type, 'ASCIIMathML'); ?>>
+			<label for="wp-mathjax-js-library-source-3">
+				<?php echo __('ASCIIMathML', 'wp-mathjax'); ?>
+				<label>
+		</div>
+	</div>
+<?php
 }
 
 /**
@@ -126,25 +131,24 @@ function wp_mathjax_input_type_callback() {
  *
  * @return void
  */
-function wp_mathjax_uninstall_option_callback() {
-	$option_uninstall_option = get_option( 'wp_mathjax_uninstall_option', 'yes' );
-	?>
+function wp_mathjax_uninstall_option_callback()
+{
+	$option_uninstall_option = get_option('wp_mathjax_uninstall_option', 'yes');
+?>
+	<div>
 		<div>
-			<div>
-				<input type="radio" name="wp_mathjax_uninstall_option" id="wp-mathjax-uninstall-option-yes" value="yes" 
-					<?php checked( $option_uninstall_option, 'yes' ); ?>>
-				<label for="wp-mathjax-uninstall-option-yes">
-					<?php echo __( 'Remove WP Mathjax generated data.', 'wp-mathjax' ); ?><br />
+			<input type="radio" name="wp_mathjax_uninstall_option" id="wp-mathjax-uninstall-option-yes" value="yes" <?php checked($option_uninstall_option, 'yes'); ?>>
+			<label for="wp-mathjax-uninstall-option-yes">
+				<?php echo __('Remove WP Mathjax generated data.', 'wp-mathjax'); ?><br />
 				<label>
-			</div>
-			<div>
-				<input type="radio" name="wp_mathjax_uninstall_option" id="wp-mathjax-uninstall-option-yes" value="no" 
-					<?php checked( $option_uninstall_option, 'no' ); ?>>
-				<label for="wp-mathjax-uninstall-option-yes">
-					<?php echo __( 'Keep WP Mathjax generated data.', 'wp-mathjax' ); ?>
-				<label>
-			</div>	
 		</div>
-		<p><em><?php echo __( 'This option only works when you uninstall this plugin.', 'wp-mathjax' ); ?></em></p>
-	<?php
+		<div>
+			<input type="radio" name="wp_mathjax_uninstall_option" id="wp-mathjax-uninstall-option-yes" value="no" <?php checked($option_uninstall_option, 'no'); ?>>
+			<label for="wp-mathjax-uninstall-option-yes">
+				<?php echo __('Keep WP Mathjax generated data.', 'wp-mathjax'); ?>
+				<label>
+		</div>
+	</div>
+	<p><em><?php echo __('This option only works when you uninstall this plugin.', 'wp-mathjax'); ?></em></p>
+<?php
 }

--- a/inc/block.php
+++ b/inc/block.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Gutenberg Block.
  *
@@ -8,37 +9,38 @@
  * @version 1.0.0
  */
 
-add_action( 'init', 'mathjax_block_init' );
+add_action('init', 'mathjax_block_init');
 
 /**
  * Initial block.
  *
  * @return void
  */
-function mathjax_block_init() {
+function mathjax_block_init()
+{
 
-    if ( ! function_exists( 'register_block_type' ) ) {
-		// Gutenberg is not active.
-		return;
-	}
+    if (!function_exists('register_block_type')) {
+        // Gutenberg is not active.
+        return;
+    }
 
     wp_register_script(
         'mathjax-gutenberg-block',
-        plugins_url( 'assets/mathjax/block-editor.js', dirname( __FILE__ ) ),
-        array( 'wp-blocks', 'wp-element' )
+        plugins_url('assets/mathjax/block-editor.js', dirname(__FILE__)),
+        array('wp-blocks', 'wp-element')
     );
 
     wp_register_style(
         'mathjax-gutenberg-block',
-        plugins_url( 'assets/mathjax/block-editor.css', dirname( __FILE__ ) ),
-        array( 'wp-edit-blocks' )
+        plugins_url('assets/mathjax/block-editor.css', dirname(__FILE__)),
+        array('wp-edit-blocks')
     );
 
-    register_block_type( 'wp-mathjax/display-block', array(
+    register_block_type('wp-mathjax/display-block', array(
         'editor_script'   => 'mathjax-gutenberg-block',
         'editor_style'    => 'mathjax-gutenberg-block',
         'render_callback' => 'mathjax_display_block_render',
-    ) );
+    ));
 }
 
 /**
@@ -48,7 +50,8 @@ function mathjax_block_init() {
  * @param string $content
  * @return string
  */
-function mathjax_display_block_render( $attr, $content = null ) {
+function mathjax_display_block_render($attr, $content = null)
+{
     global $load_mathjax_js;
     $load_mathjax_js = true;
     return $content;

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Shortcode
  *
@@ -8,7 +9,7 @@
  * @version 1.0.0
  */
 
-add_action( 'init', 'wp_mathjax_shortcode_init' );
+add_action('init', 'wp_mathjax_shortcode_init');
 
 /**
  * Initial `mathjax` short code.
@@ -16,8 +17,9 @@ add_action( 'init', 'wp_mathjax_shortcode_init' );
  * @since 1.0.0
  * @return void
  */
-function wp_mathjax_shortcode_init() {
-	add_shortcode( 'mathjax', 'wp_mathjax_shortcode' );
+function wp_mathjax_shortcode_init()
+{
+	add_shortcode('mathjax', 'wp_mathjax_shortcode');
 }
 
 /**
@@ -27,7 +29,8 @@ function wp_mathjax_shortcode_init() {
  * @param string $content
  * @return string
  */
-function wp_mathjax_shortcode( $attr, $content = null ) {
+function wp_mathjax_shortcode($attr, $content = null)
+{
 	global $load_mathjax_js;
 
 	$load_mathjax_js = true;
@@ -38,12 +41,12 @@ function wp_mathjax_shortcode( $attr, $content = null ) {
 		'mathjax'
 	);
 
-	$content = html_entity_decode( $content );
-	$content = str_replace( '<br />', "\n", $content );
-	$content = str_replace( array( '<p>', '</p>'), "\n", $content );
+	$content = html_entity_decode($content);
+	$content = str_replace('<br />', "\n", $content);
+	$content = str_replace(array('<p>', '</p>'), "\n", $content);
 	$content = preg_replace("/[\r\n]+/", "\n", $content);
 
-	$result  = sprintf( "<div class=\"mathjax\">\n%s\n</div>", $content );
+	$result  = sprintf("<div class=\"mathjax\">\n%s\n</div>", $content);
 
 	return $result;
 }

--- a/inc/smart-loader.php
+++ b/inc/smart-loader.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax - Smart loader for frontend posts.
  *
@@ -8,14 +9,14 @@
  * @version 1.0.0
  */
 
-add_action( 'loop_end', 'wp_mathjax_js_smart_loader', 10 );
+add_action('loop_end', 'wp_mathjax_js_smart_loader', 10);
 
 // We need to remove `wptexturize` to make the MathJax syntax work as expected,
 // becuase the HTML encoded characters break the syntax.
-remove_filter( 'the_content', 'wptexturize' );
+remove_filter('the_content', 'wptexturize');
 
 // Decode &lt; and &gt; to make MathML work.
-add_filter( 'the_content', 'wp_specialchars_decode', 1, 1);
+add_filter('the_content', 'wp_specialchars_decode', 1, 1);
 
 /**
  * Detect whether MathJax syntax existed in post content.
@@ -23,11 +24,12 @@ add_filter( 'the_content', 'wp_specialchars_decode', 1, 1);
  * @since 1.0.0
  * @return void
  */
-function wp_mathjax_js_smart_loader() {
+function wp_mathjax_js_smart_loader()
+{
     global $load_mathjax_js;
 
-    if ( is_mathjax_loaded_on_post() ) {
-        $load_mathjax_js = true; 
+    if (is_mathjax_loaded_on_post()) {
+        $load_mathjax_js = true;
     }
 }
 
@@ -37,23 +39,23 @@ function wp_mathjax_js_smart_loader() {
  *
  * @return bool
  */
-function is_mathjax_loaded_on_post() {
+function is_mathjax_loaded_on_post()
+{
     $is_mathjax   = false;
     $post_content = get_the_content();
 
-    
-    if ( false !== stripos( $post_content, 'wp-block-wp-mathjax-block' ) ) {
-        // Detect whether post content contains WP-MathJax block.
-        $is_mathjax = true; 
 
+    if (false !== stripos($post_content, 'wp-block-wp-mathjax-block')) {
+        // Detect whether post content contains WP-MathJax block.
+        $is_mathjax = true;
     } else {
 
         if (
             // We also support Markdown code block, for example: ```mathjax and HTML `<div class="mathjax">`
-            false !== stripos( $post_content, ' class="mathjax">' ) ||
-            false !== stripos( $post_content, ' class="language-mathjax">' )
+            false !== stripos($post_content, ' class="mathjax">') ||
+            false !== stripos($post_content, ' class="language-mathjax">')
         ) {
-            $is_mathjax = true; 
+            $is_mathjax = true;
         }
     }
 

--- a/wp-mathjax.php
+++ b/wp-mathjax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WP MathJax
  *
@@ -34,7 +35,7 @@
  * Star it, fork it, share it if you like this plugin.
  */
 
-if ( ! defined( 'WPINC' ) ) {
+if (!defined('WPINC')) {
 	die;
 }
 
@@ -57,37 +58,38 @@ if ( ! defined( 'WPINC' ) ) {
  * MATHJAX_PLUGIN_LANGUAGE_PACK : wp-mathjax/languages
  */
 
-define( 'MATHJAX_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'MATHJAX_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'MATHJAX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'MATHJAX_PLUGIN_PATH', __FILE__ );
-define( 'MATHJAX_PLUGIN_LANGUAGE_PACK', dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-define( 'MATHJAX_PLUGIN_VERSION', '1.0.0' );
-define( 'MATHJAX_PLUGIN_TEXT_DOMAIN', 'wp-mathjax' );
-define( 'MATHJAX_JS_VERSION', '8.5.0' );
+define('MATHJAX_PLUGIN_NAME', plugin_basename(__FILE__));
+define('MATHJAX_PLUGIN_DIR', plugin_dir_path(__FILE__));
+define('MATHJAX_PLUGIN_URL', plugin_dir_url(__FILE__));
+define('MATHJAX_PLUGIN_PATH', __FILE__);
+define('MATHJAX_PLUGIN_LANGUAGE_PACK', dirname(plugin_basename(__FILE__)) . '/languages');
+define('MATHJAX_PLUGIN_VERSION', '1.0.0');
+define('MATHJAX_PLUGIN_TEXT_DOMAIN', 'wp-mathjax');
+define('MATHJAX_JS_VERSION', '3.2.0');
 
 // Support WordPress version 4.7 and below.
-if ( ! function_exists( 'wp_doing_ajax' ) ) {
-	function wp_doing_ajax() {
+if (!function_exists('wp_doing_ajax')) {
+	function wp_doing_ajax()
+	{
 		return false;
 	}
 }
 
-if ( ! wp_doing_ajax() ) {
+if (!wp_doing_ajax()) {
 
-	load_plugin_textdomain( 'wp-mathjax', false, basename( dirname( __FILE__ ) ) . '/languages' ); 
+	load_plugin_textdomain('wp-mathjax', false, basename(dirname(__FILE__)) . '/languages');
 
-	if ( is_admin() ) {
-		require_once plugin_dir_path( __FILE__ ) . 'inc/admin/register.php';
-		require_once plugin_dir_path( __FILE__ ) . 'inc/admin/setting.php';
-		require_once plugin_dir_path( __FILE__ ) . 'inc/admin/menu.php';
+	if (is_admin()) {
+		require_once plugin_dir_path(__FILE__) . 'inc/admin/register.php';
+		require_once plugin_dir_path(__FILE__) . 'inc/admin/setting.php';
+		require_once plugin_dir_path(__FILE__) . 'inc/admin/menu.php';
 	}
 
 	// This is a global variable we use to identify where we want to use MathJax.js
 	$load_mathjax_js  = false;
 
-	require_once plugin_dir_path( __FILE__ ) . 'inc/block.php';
-	require_once plugin_dir_path( __FILE__ ) . 'inc/shortcode.php';
-	require_once plugin_dir_path( __FILE__ ) . 'inc/smart-loader.php';
-	require_once plugin_dir_path( __FILE__ ) . 'inc/mathjax-js.php';
+	require_once plugin_dir_path(__FILE__) . 'inc/block.php';
+	require_once plugin_dir_path(__FILE__) . 'inc/shortcode.php';
+	require_once plugin_dir_path(__FILE__) . 'inc/smart-loader.php';
+	require_once plugin_dir_path(__FILE__) . 'inc/mathjax-js.php';
 }

--- a/wp-mathjax.php
+++ b/wp-mathjax.php
@@ -65,7 +65,7 @@ define('MATHJAX_PLUGIN_PATH', __FILE__);
 define('MATHJAX_PLUGIN_LANGUAGE_PACK', dirname(plugin_basename(__FILE__)) . '/languages');
 define('MATHJAX_PLUGIN_VERSION', '1.0.0');
 define('MATHJAX_PLUGIN_TEXT_DOMAIN', 'wp-mathjax');
-define('MATHJAX_JS_VERSION', '3.2.0');
+define('MATHJAX_JS_VERSION', '2.7.8');
 
 // Support WordPress version 4.7 and below.
 if (!function_exists('wp_doing_ajax')) {


### PR DESCRIPTION
The constant MATHJAX_JS_VERSION error prevents the introduction of MathJax.js from CDN.

At the same time, the VSCode formatting tool has updated the format of some files which is not my intention but automatic.

Commit 7aab2c1 is about my preliminary exploration and file formatting, and another is about the constant.